### PR TITLE
Various fixes

### DIFF
--- a/src/kicad6-generator.coffee
+++ b/src/kicad6-generator.coffee
@@ -230,7 +230,7 @@ class Kicad6Generator
             fs.writeSync fd, sprintf(" (stroke (width #{@f}) (type default) (color 0 0 0 0)) (fill (type #{symObj.fillStyle})))\n", symObj.lineWidth)
           when 'text'
             fs.writeSync fd, "    (text \"#{symObj.text}\"\n"
-            fs.writeSync fd, sprintf("      (at #{@f} #{@f}) #{nameObj.orientation * 10})\n", symObj.x, symObj.y)
+            fs.writeSync fd, sprintf("      (at #{@f} #{@f} #{nameObj.orientation * 10})\n", symObj.x, symObj.y)
             fs.writeSync fd, "      (effects (font (size #{symObj.fontSize} #{symObj.fontSize})"
             if symObj.bold then fs.writeSync fd, " bold"
             if symObj.italic then fs.writeSync fd, " italic"

--- a/src/qeda-element.coffee
+++ b/src/qeda-element.coffee
@@ -281,7 +281,7 @@ class QedaElement
         nom = (max + min) / 2
         tol = max - min
         housing[k] = { min: min,  max: max,  nom: nom, tol: tol }
-      else if dimensions.indexOf(k) isnt -1
+      else if dimensions.indexOf(k) isnt -1 and typeof v isnt 'object'
         min = nom = max = v
         tol = 0
         housing[k] = { min: min,  max: max,  nom: nom, tol: tol }

--- a/src/qeda-library.coffee
+++ b/src/qeda-library.coffee
@@ -238,7 +238,7 @@ class QedaLibrary
       for base in bases
         baseElement = base
         if path.dirname(baseElement) is '.' then baseElement = path.dirname(element) + '/' + baseElement
-        baseObj = @loadYaml baseElement, force
+        baseObj = (@loadYaml baseElement, force)[0]
         for exclusion in exclusions
           if baseObj[exclusion]? then delete baseObj[exclusion]
         @mergeObjects baseObj, obj


### PR DESCRIPTION
This fixes the following issues:
- 'kicad6-generator': An unexpected closing parenthesis is added to text output. This breaks the ability of Kicad to parse the whole library file.
- 'qeda-element': When there are multilayer base-dependencies on components, the dimensioning incorrectly turns objects into objects of objects.
- 'qeda-library': When processing bases, baseObj is an array but treated like a json object. The expected object is in index 0 of the array. This breaks components based on others.