### PR TITLE
Allow for custom remote repository

### DIFF
--- a/bin/qeda
+++ b/bin/qeda
@@ -102,14 +102,17 @@ function resetConfig() {
 }
 
 function loadComponent(componentName) {
-  var lib = new QedaLibrary();
+  var qedaYaml = readYaml();
+  qedaYaml.config = qedaYaml.config || {};
+  var lib = new QedaLibrary(qedaYaml.config);
   lib.load(componentName, true);
 }
 
 function addComponent(componentName) {
-  var lib = new QedaLibrary();
-  lib.load(componentName);
   var qedaYaml = readYaml();
+  qedaYaml.config = qedaYaml.config || {};
+  var lib = new QedaLibrary(qedaYaml.config);
+  lib.load(componentName);
   qedaYaml.library = qedaYaml.library || [];
   qedaYaml.library.map(function (v) { return v.toLowerCase(); });
   componentName = componentName.toLowerCase();

--- a/src/qeda-library.coffee
+++ b/src/qeda-library.coffee
@@ -21,6 +21,7 @@ class QedaLibrary
 
     @connection =
       timeout: 5000
+      remote: 'https://raw.githubusercontent.com/qeda/library/master/'
 
     @nodate = false # don't put generated date in library (version control friendly)
 
@@ -209,7 +210,7 @@ class QedaLibrary
       log.start "Load '#{elementName}'"
       elementYaml = elementYaml.split('/').map((v) -> encodeURIComponent(v)).join('/')
       try
-        res = request 'GET', 'https://raw.githubusercontent.com/qeda/library/master/' + elementYaml,
+        res = request 'GET', @connection.remote + elementYaml,
           timeout: @connection.timeout
       catch error
         log.error error.message


### PR DESCRIPTION
This can be configured by setting connection.remote in the config (e.g. `qeda config connection.remote https://raw.githubusercontent.com/qeda/library/master/`). If not set, this behaves as before.